### PR TITLE
Nested groups: user id, time bucket, state

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ filename = str(input("путь:"))
 fdate = str(input("начальная дата:"))
 ldate = str(input("конечная дата:"))
 
-cdict = defaultdict(list)
 fcdate = datetime.strptime(fdate, '%Y-%m-%d').date()
 lcdate = datetime.strptime(ldate, '%Y-%m-%d').date()
 
@@ -13,22 +12,38 @@ fuserid = str(input('1 id:'))
 suserid = str(input('2 id:'))
 users = [fuserid, suserid]
 
+
+def parse_time(s):
+    s = s.strip(' \n') + "00"
+    try:
+        return datetime.strptime(s, '%Y-%m-%d %H:%M:%S.%f%z')
+    except ValueError:
+        return datetime.strptime(s, '%Y-%m-%d %H:%M:%S%z')
+
+
+def time_group(dt):
+    return dt.strftime('%Y-%m-%d %H')
+
+
+data = {}
 with open(filename, 'r') as file:
     for ln in file:
         ln = ln.split(",")
-        ln[1] = ln[1].strip('\n')
-        ln[1] += "00"
-        try:
-            ctime = datetime.strptime(ln[1], '%Y-%m-%d %H:%M:%S.%f%z')
-        except ValueError:
-            ctime = datetime.strptime(ln[1], '%Y-%m-%d %H:%M:%S%z')
-        if ln[4] in users and fcdate <= ctime.date() <= lcdate:
-            row = {
-                "userId": ln[4],
-                "state": ln[2],
-                "ctime": ctime
-            }
-            cdict[row["userId"]].append(row)
 
-print(len(cdict[fuserid]))
-print(len(cdict[suserid]))
+        ctime = parse_time(ln[1])
+        user_id = ln[4]
+        state = ln[2]
+        state_range = None
+        if len(ln) > 5:
+            state_range = ln[5] # TODO: parse time range
+
+        if user_id in users and fcdate <= ctime.date() <= lcdate:
+            z = data.setdefault(user_id, {})
+            z = z.setdefault(time_group(ctime), {})
+            z = z.setdefault(state, [])
+            z.append({"ctime": ctime, "range": state_range})
+
+
+states = data[fuserid]['2017-03-13 17']
+for s in states.items():
+    print(s)


### PR DESCRIPTION
Пример группировки сразу по нескольким критериям.
- `data` это словарь
  - ключи: идентификаторы пользователей
  - значения: словари
    - ключи: время
    - значения: словари
      - ключи: статусы
      - значения: **списки** словарей вида  `{"ctime": ..., "range": ...}`


По хорошему, для группировки по датам лучше использовать pandas, но для начала достаточно и просто префикса строки с датой. В примере дата обрезается до `%Y-%m-%d %H` и получается группировка по часам.  

Я запустил этот код и для пользователя `488` вот такой результат:
```
('Rest', [{'ctime': datetime.datetime(2017, 3, 13, 17, 9, 43, 589501, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:09:43.589501+03""'}, {'ctime': datetime.datetime(2017, 3, 13, 17, 10, 0, 979957, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:10:00.979957+03""'}])
('Ready', [{'ctime': datetime.datetime(2017, 3, 13, 17, 9, 46, 82126, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:09:46.082126+03""'}, {'ctime': datetime.datetime(2017, 3, 13, 17, 19, 48, 966573, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:19:48.966573+03""'}, {'ctime': datetime.datetime(2017, 3, 13, 17, 25, 1, 206760, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:25:01.20676+03""'}, {'ctime': datetime.datetime(2017, 3, 13, 17, 54, 11, 509138, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:54:11.509138+03""'}])
('Busy', [{'ctime': datetime.datetime(2017, 3, 13, 17, 9, 46, 174010, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:09:46.17401+03""'}, {'ctime': datetime.datetime(2017, 3, 13, 17, 20, 28, 497512, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:20:28.497512+03""'}, {'ctime': datetime.datetime(2017, 3, 13, 17, 53, 48, 405956, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800))), 'range': '"[""2017-03-13 17:53:48.405956+03""'}])
```

Видно, что он 2017-03-13 за час с 17 до 18 побывал в статусах Rest, Ready и Busy по нескольку раз.